### PR TITLE
Feature delta time for now

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Juan Madurga <jlmadurga@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,14 @@ Python's `strftime()`_:
     template = env.from_string("{% now 'utc', '%Y' %}")
 
     template.render()
+    
+You can control some timedelta offset for now time:
+
+.. code-block:: python
+
+	# Timezone 'utc' plus 3600 seconds, explicit format -> "Thu, 10 Dec 2015 16:49:01"
+    template = env.from_string("{% now 'utc' ='+3600', '%a, %d %b %Y %H:%M:%S' %}")
+
 
 Default Datetime Format
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/jinja2_time/jinja2_time.py
+++ b/jinja2_time/jinja2_time.py
@@ -17,14 +17,22 @@ class TimeExtension(Extension):
             datetime_format='%Y-%m-%d',
         )
 
-    def _now(self, timezone, datetime_format):
+    def _now(self, timezone, delta, datetime_format):
         datetime_format = datetime_format or self.environment.datetime_format
+        if delta:
+            return arrow.now(timezone).replace(
+                seconds=float(delta)).strftime(datetime_format)
         return arrow.now(timezone).strftime(datetime_format)
 
     def parse(self, parser):
         lineno = next(parser.stream).lineno
 
         args = [parser.parse_expression()]
+
+        if parser.stream.skip_if('assign'):
+            args.append(parser.parse_expression())
+        else:
+            args.append(nodes.Const(None))
 
         if parser.stream.skip_if('comma'):
             args.append(parser.parse_expression())

--- a/tests/test_now.py
+++ b/tests/test_now.py
@@ -49,3 +49,26 @@ def test_environment_datetime_format(environment):
     template = environment.from_string("{% now 'utc' %}")
 
     assert template.render() == "Wed, 09 Dec 2015 23:33:01"
+
+
+def test_delta_plus(environment):
+    template = environment.from_string(
+         "{% now 'utc' ='+86400' %}"
+        )
+    assert template.render() == "2015-12-10"
+
+
+def test_delta_subs(environment):
+    template = environment.from_string(
+         "{% now 'utc' ='-86400' %}"
+        )
+    assert template.render() == "2015-12-08"
+
+
+def test_delta_format(environment):
+    environment.datetime_format = '%a, %d %b %Y %H:%M:%S'
+
+    template = environment.from_string(
+         "{% now 'utc' ='-3661' %}"
+        )
+    assert template.render() == "Wed, 09 Dec 2015 22:32:00"

--- a/tests/test_now.py
+++ b/tests/test_now.py
@@ -66,9 +66,8 @@ def test_delta_subs(environment):
 
 
 def test_delta_format(environment):
-    environment.datetime_format = '%a, %d %b %Y %H:%M:%S'
 
     template = environment.from_string(
-         "{% now 'utc' ='-3661' %}"
+         "{% now 'utc' ='-3661', '%a, %d %b %Y %H:%M:%S' %}"
         )
     assert template.render() == "Wed, 09 Dec 2015 22:32:00"


### PR DESCRIPTION
Sometimes we need `now` time but modified with a timedelta offset. Just added another parameter for allowing do something like this

```
template = env.from_string("{% now 'utc' ='+3600' , '%a, %d %b %Y %H:%M:%S' %}")
```

It will add 3600 seconds to utc now time. You can substract with `-`.
