### PR TITLE
Drop arrow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,10 @@ Installation
 
     $ pip install jinja2-time
 
-It will automatically install `jinja2`_ along with `arrow`_.
+It will automatically install `jinja2`_ and its dependencies.
 
 .. _`jinja2`: https://github.com/mitsuhiko/jinja2
 .. _`PyPI`: https://pypi.python.org/pypi
-.. _`arrow`: https://github.com/crsmithdev/arrow
 .. _`pip`: https://pypi.python.org/pypi/pip/
 
 Usage
@@ -42,14 +41,19 @@ Usage
 Now Tag
 ~~~~~~~
 
-The extension comes with a ``now`` tag that provides convenient access to the
-`arrow.now()`_ API from your templates.
+The extension comes with a ``now`` tag that retrieves the current datetime
+in a given time zone from your templates. Time zone specifiers supported are:
+
+- ``utc``
+- ``local``
+- ``[±]HH[:][MM]``
+- Formats supported by `dateutil.tz.gettz`_ (IANA zones, GNU tz strings, etc)
 
 You can control the output by specifying a format, that will be passed to
 Python's `strftime()`_:
 
-.. _`arrow.now()`: http://crsmithdev.com/arrow/#arrow.factory.ArrowFactory.now
 .. _`strftime()`: https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior
+.. _`dateutil.tz.gettz`: https://dateutil.readthedocs.io/en/latest/tz.html#dateutil.tz.gettz
 
 .. code-block:: python
 
@@ -111,9 +115,9 @@ relative time offset:
     "{% now 'utc' - 'days=2, minutes=33, seconds=1', '%d %b %Y %H:%M:%S' %}"
 
 Further documentation on the underlying functionality can be found in the
-`arrow replace docs`_.
+`dateutil relativedelta docs`_.
 
-.. _`arrow replace docs`: http://arrow.readthedocs.io/en/latest/#replace-shift
+.. _`dateutil relativedelta docs`: https://dateutil.readthedocs.io/en/latest/relativedelta.html#module-dateutil.relativedelta
 
 
 Issues

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,8 @@ setup(
     zip_safe=False,
     install_requires=[
         'jinja2',
+        'python-dateutil>=2.3'
     ],
-    extras_require={
-        ":python_version=='2.7'": ["arrow"],
-        ":python_version<='3.4'": ["arrow<=0.13.2"],
-        ":python_version>='3.5'": ["arrow"]
-    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'jinja2',
         'python-dateutil>=2.3'
     ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*",
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
From what I can tell, [`arrow`](https://github.com/crsmithdev/arrow) is effectively unmaintained at this point or nearly so, and does not have their trove classifiers set up to support Python 3.6. We were packaging `cookiecutter` for Python 3.6 and realized that this is the main blocker on explicit support for Python 3.6.

Since the main things `jinja2_time` is using `arrow` for is as (mostly) a thin wrapper around `python-dateutil`, it is easy enough to cut out the unmaintained middleman in favor of using `python-dateutil` directly. I believe that this PR should maintain the same API.

(Note that `arrow` has also deprecated the use of relative keywords in `replace` anyway, so the `replace` parts of this need to change anyway).