### PR TITLE
Limit arrow version to 0.13.2 when install on python >3.0 and <=3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,12 @@ setup(
     zip_safe=False,
     install_requires=[
         'jinja2',
-        'arrow'
     ],
+    extras_require={
+        ":python_version=='2.7'": ["arrow"],
+        ":python_version<='3.4'": ["arrow<=0.13.2"],
+        ":python_version>='3.5'": ["arrow"]
+    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Limit arrow version to 0.13.2 when installing on python >3.0 and <=3.4.

Arrow 0.14.0 drop Python 3.2, 3.3 and 3.4 support