### PR TITLE
Bugfix/time offset

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -12,6 +12,7 @@ Pull Requests and Patches
 
 * Juan Madurga (`@jlmadurga`_)
 * Fábio C. Barrionuevo da Luz (`@luzfcb`_)
+* Ian Buchanan (`@ibuchanan`_)
 
 Bug Reports and Suggestions
 ---------------------------
@@ -21,3 +22,4 @@ None yet. Why not be the first?
 .. _`@hackebrot`: https://github.com/hackebrot
 .. _`@jlmadurga`: https://github.com/jlmadurga
 .. _`@luzfcb`: https://github.com/luzfcb
+.. _`@ibuchanan`: https://github.com/ibuchanan

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,8 @@ History
 0.3.0 (????-??-??)
 ------------------
 
-* Limit arrow version to 0.13.2 when install on python >3.0 and <=3.4
+* Dropping support for python <=3.4 because arrow dropped those.
+* Fix time offset bug caused by arrow [PR276](https://github.com/arrow-py/arrow/pull/276).
 
 
 0.2.0 (2016-06-08)

--- a/jinja2_time/jinja2_time.py
+++ b/jinja2_time/jinja2_time.py
@@ -23,7 +23,7 @@ class TimeExtension(Extension):
         for param in offset.split(','):
             interval, value = param.split('=')
             replace_params[interval.strip()] = float(operator + value.strip())
-        d = d.replace(**replace_params)
+        d = d.shift(**replace_params)
 
         if datetime_format is None:
             datetime_format = self.environment.datetime_format

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,8 @@ setup(
     zip_safe=False,
     install_requires=[
         'jinja2',
+        'arrow'
     ],
-    extras_require={
-        ":python_version=='2.7'": ["arrow"],
-        ":python_version<='3.4'": ["arrow<=0.13.2"],
-        ":python_version>='3.5'": ["arrow"]
-    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -46,9 +42,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,flake8
+envlist = py27,py35,py36,py37,py38,pypy,flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Arrow [PR267](https://github.com/arrow-py/arrow/pull/276) broke time offsets using `replace`. To fix:

* Changed arrow `replace` to `shift`.
* Removed python <3.5 from `setup.py` and `tox.ini`.
* Add corresponding documentation.
