### PR TITLE
Replace use of Arrow.replace with shift

### DIFF
--- a/jinja2_time/jinja2_time.py
+++ b/jinja2_time/jinja2_time.py
@@ -23,7 +23,7 @@ class TimeExtension(Extension):
         for param in offset.split(','):
             interval, value = param.split('=')
             replace_params[interval.strip()] = float(operator + value.strip())
-        d = d.replace(**replace_params)
+        d = d.shift(**replace_params)
 
         if datetime_format is None:
             datetime_format = self.environment.datetime_format


### PR DESCRIPTION
Hi, thanks for `jinja2time`!

This one-liner opens up the compatibility from [`<0.14.4`](https://github.com/arrow-py/arrow/blob/master/CHANGELOG.rst#0145-2019-08-09) to (apparently) the current `1.2.0` release of arrow.

This was reported over on [conda-forge](https://github.com/conda-forge/jinja2-time-feedstock/pull/9)... while technically correct, adding that pin wouldn't actually help folks much, so we'll probably carry this patch for a while.

Thanks again!